### PR TITLE
.travis.yml does not cache dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,7 @@ install:
   - mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Pci
 after_success:
   - mvn clean test jacoco:report coveralls:report -Pci
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,7 @@ after_success:
 cache:
   directories:
   - $HOME/.m2
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
Travis CI can cache content that does not often change, to speed up your build process.