### PR TITLE
🩹 修改生成站点地图信息时排除导航中的站外链接

### DIFF
--- a/src/main/java/org/b3log/solo/processor/SitemapProcessor.java
+++ b/src/main/java/org/b3log/solo/processor/SitemapProcessor.java
@@ -148,6 +148,10 @@ public class SitemapProcessor {
             if (!permalink.contains("://")) {
                 url.setLoc(Latkes.getServePath() + permalink);
             } else {
+                if (!permalink.startsWith(Latkes.getServePath())) {
+                    // Non-station link
+                    continue;
+                }
                 url.setLoc(permalink);
             }
             sitemap.addURL(url);


### PR DESCRIPTION
<!--

* PR 请提交到 dev 开发分支上

-->

目前如果导航中包含站外链接，访问 `/sitemap.xml` 时会包含站外链接地址，导致 SEO 网站存在域名权限问题，无法根据站点地图自动拉取站点链接。
