### PR TITLE
增加多个平台docker的构建

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -7,9 +7,26 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Build the Docker image
-      run: |
-        docker login --username=${{ secrets.DOCKER_HUB_USER }} --password=${{ secrets.DOCKER_HUB_PWD }}
-        docker build --build-arg git_commit=$(git rev-parse --short HEAD) -t b3log/solo:latest .
-        docker push b3log/solo
+      - uses: actions/checkout@master
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_PWD }}
+
+      - name: Build and push multi-platform Docker image
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64/v8,linux/arm/v7,windows/amd64 \
+            --build-arg git_commit=$(git rev-parse --short HEAD) \
+            -t b3log/solo:latest \
+            --push .
+
+          


### PR DESCRIPTION
在macOS上通过docker安装发现没有相应的镜像，所以修改了Workflow，支持构建多个主流平台的docker版本
>  ! solo The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested                                       0.0s 

- linux/amd64
- linux/arm64/v8
- linux/arm/v7
- windows/amd64 