### PR TITLE
fix: prevent SSRF in fetch upload by blocking private/internal IPs

### DIFF
--- a/src/main/java/org/b3log/solo/processor/FetchUploadProcessor.java
+++ b/src/main/java/org/b3log/solo/processor/FetchUploadProcessor.java
@@ -63,6 +63,19 @@ public class FetchUploadProcessor {
             return;
         }
 
+        // SSRF protection: block requests to private/internal IPs
+        try {
+            final java.net.URL parsedUrl = new java.net.URL(originalURL);
+            final java.net.InetAddress address = java.net.InetAddress.getByName(parsedUrl.getHost());
+            if (address.isLoopbackAddress() || address.isSiteLocalAddress() || address.isLinkLocalAddress()) {
+                LOGGER.log(Level.WARN, "Blocked SSRF attempt to private IP: " + originalURL);
+                return;
+            }
+        } catch (final Exception e) {
+            LOGGER.log(Level.WARN, "Failed to resolve URL host: " + originalURL);
+            return;
+        }
+
         if (Images.uploaded(originalURL)) {
             return;
         }


### PR DESCRIPTION
## Summary

Prevent SSRF in the fetch upload endpoint by validating that the target URL doesn't resolve to private or internal IP addresses.

## Problem

The `fetchUpload` method in `FetchUploadProcessor.java` fetches a user-supplied URL without SSRF protection:

```java
final String originalURL = requestJSONObject.optString(Common.URL);
if (!Strings.isURL(originalURL) || !StringUtils.startsWithIgnoreCase(originalURL, "http")) {
    return;
}
// ...
final HttpRequest req = HttpRequest.get(originalURL);
```

The only validation is that the URL starts with `http` — no check for private/internal IPs. An attacker can:
- Access cloud metadata: `http://169.254.169.254/latest/meta-data/`
- Scan internal network services
- Access internal admin interfaces

## Fix

Added IP validation using `InetAddress` after URL parsing:

```java
final InetAddress address = InetAddress.getByName(parsedUrl.getHost());
if (address.isLoopbackAddress() || address.isSiteLocalAddress() || address.isLinkLocalAddress()) {
    return;
}
```

## Impact

- **Type**: Server-Side Request Forgery (CWE-918)
- **Affected endpoint**: `fetchUpload`
- **Risk**: Cloud credential theft, internal network scanning
- **OWASP**: A10:2021 — Server-Side Request Forgery